### PR TITLE
1、修复BMFont、Spine、labelatlas资源不能正确过滤。

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 目前支持以下两种命令
 ```
 node main.js -clean 项目资源目录 结果输出文件  	// 查找未使用资源
+node main.js -clean 项目资源目录 结果输出文件	-d // 删除项目中未引用的图片、预制件、动画
 node main.js -size 项目资源目录 结果输出文件	// 按类型统计目录下所有文件从大到小排序
 ```
 例如，CocosCreator项目路径是`d:/myproject`，则进入AssetCleaner的脚本代码目录。
@@ -51,13 +52,21 @@ node main.js -clean d:/myproject/assets d:/out.txt
 ```
 查找结果将会输出到`d:/out.txt`文件。
 
-2）按类型统计assets目录下所有原始资源。命令行输入：
+2）查找未使用资源。命令行输入：
+```
+node main.js -clean d:/myproject/assets d:/out.txt -d
+或者
+node main.js -clean d:/myproject/assets d:/out.txt -delete
+```
+删除结果默认将会输出到`d:/myproject/assets/cleanFiles.txt`文件。
+
+3）按类型统计assets目录下所有原始资源。命令行输入：
 ```
 node main.js -size d:/myproject/assets d:/out.txt
 ```
 查找结果输出到`d:/out.txt`文件。
 
-3）按类型统计构建后的build/web-mobile目录下所有文件。命令行输入：
+4）按类型统计构建后的build/web-mobile目录下所有文件。命令行输入：
 ```
 node main.js -size d:/myproject/build/web-mobile d:/out.txt
 ```

--- a/src/FileHelper.js
+++ b/src/FileHelper.js
@@ -62,6 +62,14 @@ let FileHelper = {
         return fs.readFileSync(fullPath).toString();
     },
 
+    // 函数防抖
+    debounce(fn, wait = 1000) {
+        var timeout = null;
+        return function() {
+            timeout && clearTimeout(timeout);
+            timeout = setTimeout(fn, wait);
+        }
+    }
 };
 
 module.exports = FileHelper;

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,14 @@ const AssetSize = require('./AssetSize');
 let command = process.argv[2];
 let sourceFile = process.argv[3];
 let destFile = process.argv[4];
+global._delete = process.argv.includes('-d') || process.argv.includes('-delete') // 删除未引用的资源
+global._excludes = process.argv.filter(n => n.includes('-e=') || n.includes('-excludes=')).map(node => { // 删除未引用的资源时，需要排除的文件或路径，支持字符串或正则
+    let _i = node.replace('-e=', '')
+    if (_i !== node) return _i
+    _i = node.replace('-excludes=', '')
+    if (_i !== node) return _i
+    return ''
+})[0]
 
 let Version = 'AssetCleaner 1.1';
 let parseCommand = function(cmd) {


### PR DESCRIPTION
2、修复同一目录下有多个Spine动画时资源判断逻辑错误。
3、修复一个Spine动画引用多个图片时，与配置文件不同名称的图片，过滤错误。
4、新增-d或-delete命令行参数，可自动删除未引用资源。
5、删除的资源日志，默认会在项目资源目录下面生成一个cleanFiles.txt文件。